### PR TITLE
fix: dueDate format in UpdateTaskRequest and task normalization

### DIFF
--- a/backend/src/Application/Dto/Task/UpdateTaskRequest.php
+++ b/backend/src/Application/Dto/Task/UpdateTaskRequest.php
@@ -30,7 +30,7 @@ class UpdateTaskRequest
     #[Assert\PositiveOrZero]
     public ?int $sortOrder = null;
 
-    #[Assert\DateTime]
+    #[Assert\DateTime(format: 'Y-m-d\TH:i:s.vP')]
     public ?string $dueDate = null;
 
     #[Assert\Url]

--- a/frontend/src/modules/tasks/components/TaskCardCreator.vue
+++ b/frontend/src/modules/tasks/components/TaskCardCreator.vue
@@ -153,7 +153,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from "vue";
+import { ref, onMounted, watch, toRaw } from "vue";
 import TasksCardCreatorUserSelector from "./TaskCardCreatorUserSelector.vue";
 import TasksCardCreatorDueDateSelector from "./TaskCardCreatorDueDateSelector.vue";
 import TaskCardViewTicksList from "./TaskCardViewTicksList.vue";
@@ -215,7 +215,12 @@ const ticksStore = useTicksStore();
 
 // Determine if we are working on editing a task or creating a new one
 const taskToWork = props.taskToEdit
-  ? structuredClone(props.taskToEdit)
+  ? {
+      ...JSON.parse(JSON.stringify(toRaw(props.taskToEdit))),
+      dueDate: props.taskToEdit.dueDate
+        ? new Date(props.taskToEdit.dueDate)
+        : createNewDate(),
+    }
   : createNewTask();
 
 const task = ref(taskToWork);

--- a/frontend/src/services/tasks-service.js
+++ b/frontend/src/services/tasks-service.js
@@ -11,15 +11,21 @@ class TasksService extends HttpClient {
     // Removing unnecessary frontend-only parameters from the task
     // eslint-disable-next-line no-unused-vars
     const { ticks, comments, status, timeStatus, user, ...request } = task;
+    // Normalize dueDate format for Symfony validator (convert Z to +00:00)
+    if (request.dueDate instanceof Date) {
+      request.dueDate = request.dueDate.toISOString().replace("Z", "+00:00");
+    }
     return request;
   }
 
   normalizeTask(task) {
+    const statusId = task.statusId ?? task.status?.id ?? null;
     return {
       ...task,
       ticks: task.ticks || [],
       dueDate: task.dueDate ? new Date(task.dueDate) : null,
-      status: task.statusId ? taskStatuses[task.statusId] : "",
+      statusId,
+      status: statusId ? taskStatuses[statusId] : "",
       timeStatus: getTimeStatus(task.dueDate),
       columnId: task.column?.id ?? null,
     };


### PR DESCRIPTION
Follow-up fixes after testing task create/edit flow end to end.

## What was broken

- UpdateTaskRequest was missing the DateTime format constraint - dueDate validation worked on create but not on update
- structuredClone on a Vue reactive proxy drops the Date object type, switched to JSON.parse(JSON.stringify(toRaw())) and explicitly reconstruct dueDate as Date
- tasks-service was normalizing statusId incorrectly when the API returns status as a nested object instead of a flat id
- dueDate serialization: convert JS Date to ISO string and replace Z with +00:00 so Symfony accepts it